### PR TITLE
Pin libressl source tag and make versions.json the single source of truth

### DIFF
--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+set -euo pipefail
+
+LIBRESSL_VERSION=$(jq -r '.libressl.version' versions.json)
 
 # LibreSSL OpenBSD codebase branch fix
-echo libressl-v4.3.1 >workspace/libressl/OPENBSD_BRANCH
+echo "libressl-${LIBRESSL_VERSION}" >workspace/libressl/OPENBSD_BRANCH
 sed -i '/LIBRESSL_GIT_OPTIONS="\${LIBRESSL_GIT_OPTIONS:- --depth=8}"/d' ./workspace/libressl/update.sh

--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # LibreSSL OpenBSD codebase branch fix
-#echo libressl-v4.0.0 >workspace/libressl/OPENBSD_BRANCH
+echo libressl-v4.3.1 >workspace/libressl/OPENBSD_BRANCH
 sed -i '/LIBRESSL_GIT_OPTIONS="\${LIBRESSL_GIT_OPTIONS:- --depth=8}"/d' ./workspace/libressl/update.sh

--- a/script/updater/check-updates.py
+++ b/script/updater/check-updates.py
@@ -1,45 +1,40 @@
 #!/usr/bin/env python3
-import csv
-import re
+import json
 import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(".")
-POLICY = ROOT / 'script' / 'updater' / 'update-policy.csv'
+VERSIONS = ROOT / 'versions.json'
 WORKSPACE = ROOT / 'workspace'
 README = ROOT / 'README.md'
+
+TABLE_HEADER = ['| Components | Commit Tag |', '|--|--|']
 
 
 def run(cmd, cwd=None):
     return subprocess.check_output(cmd, cwd=cwd or ROOT, text=True).strip()
 
 
-def parse_policies():
-    policies = []
-    with POLICY.open() as f:
-        for name, policy, *rest in csv.reader(f):
-            name = name.strip()
-            if not name or name.startswith('#'):
-                continue
-            policy = policy.strip()
-            param = rest[0].strip() if rest else ''
-            policies.append((name, policy, param))
-    return policies
+def load_versions() -> dict:
+    with VERSIONS.open() as f:
+        return json.load(f)
+
+
+def save_versions(versions: dict):
+    with VERSIONS.open('w') as f:
+        json.dump(versions, f, indent=2)
+        f.write('\n')
 
 
 def get_latest_tag(path: Path):
-    # fetch all tags so that we have the latest metadata
     run(['git', 'fetch', '--tags'], cwd=path)
-
-    # list tags sorted by version (newest first)
     tags = run([
         'git', 'for-each-ref',
         '--sort=-version:refname',
         '--format=%(refname:short)',
         'refs/tags'
     ], cwd=path).splitlines()
-
     return tags[0] if tags else None
 
 
@@ -49,74 +44,69 @@ def get_latest_commit(path: Path, branch: str):
 
 
 def update_submodule(path: Path, new_ref: str):
-    # checkout the new ref (tag or commit) inside the submodule
     run(['git', '-C', str(path), 'checkout', new_ref])
-    # stage the submodule change in the superproject
     run(['git', 'add', str(path)])
 
 
-def update_readme(updates: dict[str, tuple[str,str]]):
+def rewrite_readme(versions: dict):
     lines = README.read_text().splitlines()
-    touched = []
+    start = end = None
     for i, line in enumerate(lines):
-        if not line.startswith('|'):
+        if start is None and line.strip() == TABLE_HEADER[0]:
+            start = i
             continue
-        parts = [p.strip() for p in line.split('|')[1:-1]]
-        if len(parts) < 2:
-            continue
-        comp = parts[0].lower()
-        if comp in updates:
-            _, new_ver = updates[comp]
-            parts[1] = new_ver
-            lines[i] = '| ' + ' | '.join(parts) + ' |'
-            touched.append(comp)
-    if touched:
-        README.write_text('\n'.join(lines) + '\n')
-    return touched
+        if start is not None and not line.startswith('|'):
+            end = i
+            break
+    if start is None:
+        return
+    if end is None:
+        end = len(lines)
+
+    body = [f'| {name} | {entry["version"]} |' for name, entry in versions.items()]
+    new_block = [TABLE_HEADER[0], TABLE_HEADER[1], *body]
+    lines[start:end] = new_block
+    README.write_text('\n'.join(lines) + '\n')
 
 
 def main():
-    policies = parse_policies()
+    versions = load_versions()
     updates = {}
 
-    for name, policy, param in policies:
+    for name, entry in versions.items():
         comp_dir = WORKSPACE / name
         if not comp_dir.exists():
             continue
 
+        policy = entry.get('policy')
         if policy == 'tag':
             new_ref = get_latest_tag(comp_dir)
         elif policy == 'branch':
-            new_ref = get_latest_commit(comp_dir, param)
+            new_ref = get_latest_commit(comp_dir, entry['branch'])
         else:
             continue
 
         if not new_ref:
             continue
 
-        # extract current version from README table (case-insensitive match)
-        m = re.search(
-            rf'\|\s*{re.escape(name)}\s*\|\s*([^|\s]+)\s*\|',
-            README.read_text(),
-            re.IGNORECASE
-        )
-        current = m.group(1).strip() if m else ''
-
+        current = entry['version']
         if new_ref != current:
-            updates[name.lower()] = (current, new_ref)
+            updates[name] = (current, new_ref)
             update_submodule(comp_dir, new_ref)
+            entry['version'] = new_ref
 
     if not updates:
         print("No updates found.", file=sys.stderr)
         sys.exit(0)
 
-    touched = update_readme(updates)
+    save_versions(versions)
+    rewrite_readme(versions)
+    run(['git', 'add', str(VERSIONS)])
+    run(['git', 'add', str(README)])
 
-    # emit a markdown summary for the PR body
     print("## Updated Components\n")
-    for comp in touched:
-        old, new = updates[comp]
-        print(f"- **{comp}**: `{old}` → `{new}`")
+    for name, (old, new) in updates.items():
+        print(f"- **{name}**: `{old}` → `{new}`")
     print("\n*This PR was generated automatically by GitHub Actions.*")
 
 

--- a/script/updater/update-policy.csv
+++ b/script/updater/update-policy.csv
@@ -1,6 +1,0 @@
-libressl,tag,
-nginx,tag,
-brotli,branch,master
-pcre2,tag,
-zlib,tag,
-zstd,branch,master

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,28 @@
+{
+  "nginx": {
+    "version": "release-1.31.0",
+    "policy": "tag"
+  },
+  "libressl": {
+    "version": "v4.3.1",
+    "policy": "tag"
+  },
+  "pcre2": {
+    "version": "pcre2-10.47",
+    "policy": "tag"
+  },
+  "zlib": {
+    "version": "v1.3.2",
+    "policy": "tag"
+  },
+  "brotli": {
+    "version": "e4389d7bb41efb5e59c0416a6bfd7b257c32738b",
+    "policy": "branch",
+    "branch": "master"
+  },
+  "zstd": {
+    "version": "057a7d339af1111d04b5a9ac5ae9b0250d17cd94",
+    "policy": "branch",
+    "branch": "master"
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes the alpine/amd64 build failure (run [25896600403](https://github.com/wxx9248/NGINX-Build/actions/runs/25896600403/job/76110914903)) where libressl-portable's `mlkem_internal.h.patch` failed to apply because `update.sh` was pulling libressl OpenBSD `master` (a day past our pinned libressl-portable v4.3.1, which removed the now-upstreamed patch).
- Pins the OpenBSD source via `OPENBSD_BRANCH=libressl-v4.3.1` in `patches/apply.sh`, matching the pinned libressl-portable v4.3.1 submodule.
- Refactors pinned dependency versions into `versions.json` at the repo root — single source of truth read by both `check-updates.py` and `patches/apply.sh`. `update-policy.csv` is folded in; README table is now regenerated from JSON.

## Changes
- `versions.json` (new) — `{version, policy[, branch]}` per component.
- `patches/apply.sh` — reads `.libressl.version` via `jq`; writes `libressl-<version>` to `OPENBSD_BRANCH`.
- `script/updater/check-updates.py` — JSON-driven; rewrites README table deterministically; stages JSON + README alongside submodule bumps.
- `script/updater/update-policy.csv` — removed.

## Test plan
- [x] CI: `build-linux-binary.yaml` (alpine/amd64) passes the "Applying patches" step.
- [ ] CI: full docker assembly job that previously failed now succeeds end-to-end.
- [ ] Manual: trigger `check-updates.yaml` via `workflow_dispatch` and confirm the auto-PR diff includes `versions.json` + `README.md` + submodule SHA bumps when an upstream change exists, and prints "No updates found." otherwise.
- [ ] Manual: temporarily edit `versions.json` to bump `libressl.version` and rerun the build — `apply.sh` should pick up the new tag without further edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)